### PR TITLE
Measure go test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,12 @@ test/bindata.go: $(wildcard ./test/assets/**)
 test-api: test/bindata.go
 	go clean -testcache && go test ./test
 
+coverage:
+	build/coverage.sh
+
+print-coverage:
+	go tool cover -html artifacts/cover.out
+
 clean:
 	cd artifacts && rm -rf `ls . | grep -v 'cache'`
 
@@ -56,3 +62,4 @@ link-repo:
 
 .PHONY: init main all all-debug generate test clean fmt validate link-repo
 .PHONY: ui server
+.PHONY: coverage print-coverage

--- a/build/coverage.sh
+++ b/build/coverage.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+go test -v -coverprofile artifacts/cover.out \
+      -coverpkg="$(go list \
+          git.proxeus.com/core/central/main/... \
+          git.proxeus.com/core/central/sys/... \
+          | tr '\n' ',' | sed 's/.$//')" \
+  ./main

--- a/main/config/configuration.go
+++ b/main/config/configuration.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"flag"
 
@@ -32,7 +33,7 @@ type Configuration struct {
 var Config Configuration
 
 func init() {
-	if flag.Lookup("test.v") != nil {
+	if strings.HasSuffix(os.Args[0], ".test") {
 		return
 	}
 	flagStruct(Config)

--- a/main/main_test.go
+++ b/main/main_test.go
@@ -1,0 +1,7 @@
+package main
+
+import "testing"
+
+func TestCoverage(m *testing.T) {
+	main()
+}


### PR DESCRIPTION
# Pull Request Details

The goal is to measure integration tests coverage by starting backend in coverage measuring mode using standard go tooling.
