### PR TITLE
Implement mongoDB as a second database choice

### DIFF
--- a/demo/mongodb/docker-compose.yml
+++ b/demo/mongodb/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3"
+services:
+  mongo1:
+    hostname: mongo1
+    container_name: localmongo1
+    image: mongo:latest
+    ports:
+      - 27017:27017
+    restart: unless-stopped
+    entrypoint: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0" ]
+  mongo2:
+    hostname: mongo2
+    container_name: localmongo2
+    image: mongo:latest
+    ports:
+      - 27018:27018
+    restart: unless-stopped
+    entrypoint: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0", "--port", "27018" ]
+  mongo3:
+    hostname: mongo3
+    container_name: localmongo3
+    image: mongo:latest
+    ports:
+      - 27019:27019
+    restart: unless-stopped
+    entrypoint: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0", "--port", "27019" ]

--- a/demo/mongodb/mongodb-single/docker-compose.yml
+++ b/demo/mongodb/mongodb-single/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3"
+services:
+  mongo1:
+    hostname: mongo1-single
+    container_name: localmongo1-single
+    image: mongo:latest
+    ports:
+      - 27017:27017
+    restart: unless-stopped
+    entrypoint: [ "/usr/bin/mongod"]

--- a/demo/mongodb/replica-set.config
+++ b/demo/mongodb/replica-set.config
@@ -1,0 +1,2 @@
+  config={"_id":"rs0","members":[{"_id":0,"host":"mongo1:27017"},{"_id":1,"host":"mongo2:27018"},{"_id":2,"host":"mongo3:27019"}]}
+  rs.initiate(config)

--- a/go.mod
+++ b/go.mod
@@ -51,8 +51,10 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/valyala/fasthttp v0.0.0-20171207120941-e5f51c11919d // indirect
 	github.com/valyala/fasttemplate v1.0.1 // indirect
-	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
+	github.com/vmihailenco/msgpack v4.0.4+incompatible
 	github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad // indirect
+	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c // indirect
+	github.com/xdg/stringprep v1.0.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.1.0 // indirect
@@ -61,6 +63,7 @@ require (
 	github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 // indirect
 	github.com/yudai/pp v2.0.1+incompatible // indirect
 	go.etcd.io/bbolt v1.3.3
+	go.mongodb.org/mongo-driver v1.2.0
 	golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f
 	golang.org/x/image v0.0.0-20190523035834-f03afa92d3ff // indirect
 	google.golang.org/appengine v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -270,6 +270,10 @@ github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad h1:W0LEBv82YCGEtc
 github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad/go.mod h1:Hy8o65+MXnS6EwGElrSRjUzQDLXreJlzYLlWiHtt8hM=
 github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208 h1:1cngl9mPEoITZG8s8cVcUy5CeIBYhEESkOB7m6Gmkrk=
 github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208/go.mod h1:IotVbo4F+mw0EzQ08zFqg7pK3FebNXpaMsRy2RT+Ees=
+github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c h1:u40Z8hqBAAQyv+vATcGgV0YCnDjqSL7/q/JyPhhJSPk=
+github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
+github.com/xdg/stringprep v1.0.0 h1:d9X0esnoa3dFsV0FG35rAT0RIhYFlPq7MiP+DW89La0=
+github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
@@ -287,6 +291,8 @@ github.com/yudai/pp v2.0.1+incompatible/go.mod h1:PuxR/8QJ7cyCkFp/aUDS+JY727OFEZ
 go.etcd.io/bbolt v1.3.0/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3 h1:MUGmc65QhB3pIlaQ5bB4LwqSj6GIonVJXpZiaKNyaKk=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
+go.mongodb.org/mongo-driver v1.2.0 h1:6fhXjXSzzXRQdqtFKOI1CDw6Gw5x6VflovRpfbrlVi0=
+go.mongodb.org/mongo-driver v1.2.0/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f h1:R423Cnkcp5JABoeemiGEPlt9tHXFfw5kvc0yqlxRPWo=
@@ -303,6 +309,7 @@ golang.org/x/net v0.0.0-20190628185345-da137c7871d7 h1:rTIdg5QFRR7XCaK4LCjBiPbx8
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/main/app/document.go
+++ b/main/app/document.go
@@ -11,17 +11,17 @@ import (
 	"sync"
 
 	"github.com/ProxeusApp/proxeus-core/storage"
-
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/labstack/echo"
-
 	"github.com/ProxeusApp/proxeus-core/sys"
 	"github.com/ProxeusApp/proxeus-core/sys/eio"
 	"github.com/ProxeusApp/proxeus-core/sys/file"
 	"github.com/ProxeusApp/proxeus-core/sys/form"
 	"github.com/ProxeusApp/proxeus-core/sys/model"
+	"github.com/ProxeusApp/proxeus-core/sys/model/compatability"
 	"github.com/ProxeusApp/proxeus-core/sys/validate"
 	"github.com/ProxeusApp/proxeus-core/sys/workflow"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/labstack/echo"
 )
 
 //TODO replace DataCluster with file.MapIO. DataCluster was meant to be used for guest users only to prevent from storing data that will be never used again after the session is expired
@@ -628,7 +628,7 @@ func (me *FormNodeImpl) Execute(n *workflow.Node) (proceed bool, err error) {
 	//formData, err := me.ctx.getDataFor(n.ID)
 	formDataIf, _ := me.ctx.getDataByPath("input")
 	var formData map[string]interface{}
-	if v, ok := formDataIf.(map[string]interface{}); ok {
+	if v, ok := compatability.ToMapStringIF(formDataIf); ok {
 		formData = v
 	}
 	me.ctx.statusResult.CurrentType = n.Type

--- a/main/app/execute_at_once.go
+++ b/main/app/execute_at_once.go
@@ -2,14 +2,13 @@ package app
 
 import (
 	"archive/zip"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
-
-	"github.com/asdine/storm"
 
 	"github.com/ProxeusApp/proxeus-core/main/www"
 	"github.com/ProxeusApp/proxeus-core/sys/eio"
@@ -169,7 +168,7 @@ func (me *EAOFormNodeImpl) getDataFor(formItem *model.FormItem, id string) (map[
 		}
 		return formData, nil
 	}
-	return nil, storm.ErrNotFound
+	return nil, errors.New("not found")
 }
 
 func (me *EAOFormNodeImpl) Execute(n *workflow.Node) (proceed bool, err error) {
@@ -226,7 +225,7 @@ func (me *EAODocTmplNodeImpl) Execute(n *workflow.Node) (proceed bool, err error
 			return false, err
 		}
 	} else {
-		return false, storm.ErrNotFound
+		return false, errors.New("not found")
 	}
 	return true, nil
 }

--- a/main/handlers/formbuilder/handlers.go
+++ b/main/handlers/formbuilder/handlers.go
@@ -64,7 +64,9 @@ func GetOneFormHandler(e echo.Context) error {
 	sess := c.Session(true)
 	if sess != nil {
 		item, err := c.System().DB.Form.Get(sess, formID)
-		if err == nil {
+		if err != nil {
+			return c.String(http.StatusNotFound, err.Error())
+		} else {
 			return c.JSON(http.StatusOK, item)
 		}
 	}
@@ -75,11 +77,12 @@ func UpdateFormHandler(e echo.Context) error {
 	c := e.(*www.Context)
 	ID := c.QueryParam("id")
 	sess := c.Session(false)
+	var err error
 	if sess != nil {
 		if strings.Contains(c.Request().Header.Get("Content-Type"), "application/json") {
 			body, _ := ioutil.ReadAll(c.Request().Body)
 			item := model.FormItem{}
-			err := json.Unmarshal(body, &item)
+			err = json.Unmarshal(body, &item)
 			if err == nil {
 				item.ID = ID
 				err = c.System().DB.Form.Put(sess, &item)
@@ -89,7 +92,7 @@ func UpdateFormHandler(e echo.Context) error {
 			}
 		}
 	}
-	return c.NoContent(http.StatusBadRequest)
+	return c.String(http.StatusBadRequest, err.Error())
 }
 
 func GetComponentsHandler(e echo.Context) error {

--- a/main/handlers/formbuilder/test_handlers.go
+++ b/main/handlers/formbuilder/test_handlers.go
@@ -181,10 +181,9 @@ func PostFileIdFieldName(e echo.Context) error {
 }
 
 func GetDataManager(sess *session.Session) form.DataManager {
-	var dc form.DataManager
-	sess.Get("testDC", &dc)
-	if dc == nil {
-		dc = form.NewDataManager(sess.SessionDir())
+	dc := form.NewDataManager(sess.SessionDir())
+	err := sess.Get("testDC", &dc)
+	if err != nil {
 		sess.Put("testDC", dc)
 	}
 	return dc

--- a/main/main.go
+++ b/main/main.go
@@ -68,11 +68,10 @@ func main() {
 		allTrans, _ := system.DB.I18n.GetAll(lang)
 		for k, v := range trans {
 			if _, exists := allTrans[k]; !exists {
-				fmt.Println("inserting initial translation:", k, "::::", v)
 				_ = system.DB.I18n.Put(lang, k, v)
 			}
 		}
-		err = system.DB.I18n.PutLang("en", true)
+		err := system.DB.I18n.PutLang("en", true)
 		if err != nil {
 			fmt.Println("Error activating fallback lang: ", err)
 		}

--- a/storage/database/common.go
+++ b/storage/database/common.go
@@ -1,0 +1,23 @@
+package database
+
+import (
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/mongo"
+
+	"github.com/asdine/storm"
+)
+
+func OpenDatabase(engine, uri, name string) (DB, error) {
+	switch engine {
+	case "mongo":
+		return OpenMongo(uri, name)
+	case "storm", "":
+		return OpenStorm(name)
+	}
+	return nil, fmt.Errorf("unknown database engine '%s'", engine)
+}
+
+func NotFound(err error) bool {
+	return err == mongo.ErrNoDocuments || err == storm.ErrNotFound
+}

--- a/storage/database/mongo.go
+++ b/storage/database/mongo.go
@@ -1,0 +1,446 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/asdine/storm/q"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+type MongoShim struct {
+	db          *mongo.Database
+	collections map[string]*mongo.Collection // type to collection mapping
+	context     context.Context
+	sess        mongo.Session
+}
+
+const initializedKey = "initialized"
+
+func OpenMongo(dbURI string, dbName string) (*MongoShim, error) {
+	spl := strings.Split(dbName, "/")
+	dbName = spl[len(spl)-1]
+	client, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(dbURI))
+	if err != nil {
+		return nil, err
+	}
+	db := client.Database(dbName)
+	return &MongoShim{
+		db:          db,
+		collections: map[string]*mongo.Collection{},
+		context:     context.TODO()}, nil
+}
+
+func (s *MongoShim) ctx() context.Context {
+	inTransaction := s.sess != nil
+	if inTransaction {
+		var sc mongo.SessionContext
+		mongo.WithSession(s.context, s.sess, func(sessionContext mongo.SessionContext) error {
+			sc = sessionContext
+			return nil
+		})
+		return sc
+	}
+	return s.context
+}
+
+func (s *MongoShim) nameToCollection(n string) *mongo.Collection {
+	if c, ok := s.collections[n]; ok {
+		return c
+	}
+	c := s.db.Collection(n)
+	s.assureUniqueIndex(c)
+	s.collections[n] = c
+	// just to force collection creation as implicit creation doesn't work for transactions
+	c.UpdateOne(s.ctx(), bson.M{"K": initializedKey}, bson.M{"$set": bson.M{"V": true}},
+		options.Update().SetUpsert(true))
+	return c
+}
+
+func (s *MongoShim) assureUniqueIndex(c *mongo.Collection) {
+	i := mongo.IndexModel{
+		Keys: bson.M{
+			"K":    1,
+			"V.id": 1,
+		},
+		Options: options.Index().SetUnique(true).SetName("custom-keys"),
+	}
+	c.Indexes().CreateOne(s.ctx(), i)
+}
+
+func (s *MongoShim) objectToCollection(o interface{}) *mongo.Collection {
+	t := reflect.Indirect(reflect.ValueOf(o)).Type()
+	return s.typeToCollection(t)
+}
+
+func (s *MongoShim) typeToCollection(t reflect.Type) *mongo.Collection {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	return s.nameToCollection(t.Name())
+}
+
+// Get a value from a bucket
+func (s *MongoShim) Get(bucketName string, key interface{}, to interface{}) error {
+	c := s.nameToCollection(bucketName)
+	var raw bson.Raw
+	err := c.FindOne(s.ctx(), bson.M{"K": key}).Decode(&raw)
+	if err != nil {
+		return err
+	}
+	return raw.Lookup("V").Unmarshal(to)
+}
+
+// Set a key/value pair into a bucket
+func (s *MongoShim) Set(bucketName string, key interface{}, value interface{}) error {
+	if t := reflect.ValueOf(key).Type().Kind(); t != reflect.String {
+		return fmt.Errorf("required string type got %s", t.String())
+	}
+	c := s.nameToCollection(bucketName)
+	_, err := c.UpdateOne(s.ctx(), bson.M{"K": key}, bson.M{"$set": bson.M{"V": value}},
+		options.Update().SetUpsert(true))
+	return err
+}
+
+// Delete deletes a key from a bucket
+func (s *MongoShim) Delete(bucketName string, key interface{}) error {
+	c := s.nameToCollection(bucketName)
+	d, err := c.DeleteOne(s.ctx(), bson.M{"K": key})
+	if err != nil {
+		return err
+	}
+	// compatibility quirk
+	if d.DeletedCount == 0 {
+		return mongo.ErrNoDocuments
+	}
+	return nil
+}
+
+// Begin starts a new transaction
+func (s *MongoShim) Begin(_ bool) (DB, error) {
+	var err error
+	s.sess, err = s.db.Client().StartSession()
+	if err != nil {
+		return s, err
+	}
+	err = s.sess.StartTransaction()
+	return s, err
+}
+
+func (s *MongoShim) WithBatch(enabled bool) DB {
+	// Not implemented
+	return s
+}
+
+func (s *MongoShim) Rollback() error {
+	if s.sess == nil {
+		return nil
+	}
+	err := s.sess.AbortTransaction(s.ctx())
+	if err != nil {
+		return err
+	}
+	s.sess.EndSession(s.ctx())
+	s.sess = nil
+	return nil
+}
+
+func (s *MongoShim) Commit() error {
+	if s.sess == nil {
+		return nil
+	}
+	err := s.sess.CommitTransaction(s.ctx())
+	if err != nil {
+		return err
+	}
+	s.sess.EndSession(s.ctx())
+	s.sess = nil
+	return nil
+}
+
+// Select a list of records that match a list of matchers. Doesn't use indexes.
+func (s *MongoShim) Select(matchers ...q.Matcher) Query {
+	// TODO: translate matchers into bson query to improve performance
+	return &MongoQuery{matcher: q.And(matchers...), s: s}
+}
+
+// Init creates the indexes and buckets for a given structure
+func (s *MongoShim) Init(data interface{}) error {
+	if str, ok := data.(string); ok {
+		s.nameToCollection(str)
+	} else {
+		s.objectToCollection(data)
+	}
+	return nil
+}
+
+// ReIndex rebuilds all the indexes of a bucket
+func (s *MongoShim) ReIndex(data interface{}) error {
+	return nil
+}
+
+func (s *MongoShim) bucketAndKey(data interface{}) (bucket string, key interface{}, err error) {
+	c := s.objectToCollection(data)
+	id := reflect.Indirect(reflect.ValueOf(data)).FieldByName("ID")
+	if !id.IsValid() {
+		return "", "", errors.New("no ID field provided")
+	}
+	return c.Name(), id.Interface(), nil
+}
+
+// Save a structure
+func (s *MongoShim) Save(data interface{}) error {
+	bucket, key, err := s.bucketAndKey(data)
+	if err != nil {
+		return err
+	}
+	return s.Set(bucket, key, data)
+}
+
+// Update a structure
+func (s *MongoShim) Update(data interface{}) error {
+	return s.Save(data)
+}
+
+// DeleteStruct deletes a structure from the associated bucket
+func (s *MongoShim) DeleteStruct(data interface{}) error {
+	bucket, key, err := s.bucketAndKey(data)
+	if err != nil {
+		return err
+	}
+	return s.Delete(bucket, key)
+}
+
+// One returns one record by the specified index
+func (s *MongoShim) One(fieldName string, value interface{}, to interface{}) error {
+	c := s.objectToCollection(to)
+	var raw bson.Raw
+	err := c.FindOne(s.ctx(), bson.M{"V." + strings.ToLower(fieldName): value}).Decode(&raw)
+	if err != nil {
+		return err
+	}
+	return raw.Lookup("V").Unmarshal(to)
+}
+
+// Count all the matching records
+func (s *MongoShim) Count(data interface{}) (int, error) {
+	c := s.objectToCollection(data)
+	count, err := c.CountDocuments(s.ctx(), bson.D{})
+	count-- // subtract initializedKey
+	return int(count), err
+}
+
+func (s *MongoShim) findWithConstraints(filter interface{}, to interface{}, q *MongoQuery) (int64, error) {
+	// *to* can be a pointer to slice of elements or pointer to an element
+	var resultsToSlice bool
+	var resultsCount int64
+	typ := reflect.Indirect(reflect.ValueOf(to)).Type()
+	if typ.Kind() == reflect.Slice {
+		resultsToSlice = true
+		// clear result slice
+		toV := reflect.Indirect(reflect.ValueOf(to))
+		toV.Set(reflect.MakeSlice(typ, 0, toV.Cap()))
+		// set slice element type
+		typ = typ.Elem()
+	}
+	c := s.typeToCollection(typ)
+
+	cur, err := c.Find(s.ctx(), filter, q.opts())
+	if err != nil {
+		return resultsCount, err
+	}
+	defer cur.Close(s.ctx())
+
+	var skipFirstN int64
+	if q.skip != nil {
+		skipFirstN = *q.skip
+	}
+	limitN := int64(-1)
+	if q.limit != nil {
+		limitN = *q.limit
+	}
+
+	for cur.Next(s.ctx()) {
+		if cur.Err() != nil {
+			return resultsCount, cur.Err()
+		}
+		var raw bson.Raw
+		err = cur.Decode(&raw)
+		if err != nil {
+			return resultsCount, err
+		}
+
+		if raw.Lookup("K").StringValue() == initializedKey {
+			continue
+		}
+
+		sliceElemPtr := reflect.New(typ).Interface()
+		sliceElemV := func() reflect.Value {
+			return reflect.Indirect(reflect.ValueOf(sliceElemPtr))
+		}
+
+		err = raw.Lookup("V").Unmarshal(sliceElemPtr)
+		if err != nil {
+			return resultsCount, err
+		}
+
+		if q.matcher != nil {
+			success, err := q.matcher.Match(sliceElemV().Interface())
+			if err != nil {
+				return resultsCount, err
+			}
+			if !success {
+				// skip this element
+				continue
+			}
+		}
+
+		if skipFirstN > 0 {
+			skipFirstN--
+			continue
+		}
+		if limitN == 0 {
+			return resultsCount, nil
+		}
+		limitN--
+
+		// got valid result
+		resultsCount++
+		if q.callback != nil {
+			err = q.callback(sliceElemV().Addr().Interface())
+			if err != nil {
+				return resultsCount, err
+			}
+		} else {
+			if resultsToSlice {
+				// append to result slice
+				reflect.Indirect(reflect.ValueOf(to)).Set(
+					reflect.Append(reflect.Indirect(reflect.ValueOf(to)), sliceElemV()))
+			} else {
+				// set to result element
+				reflect.Indirect(reflect.ValueOf(to)).Set(sliceElemV())
+			}
+		}
+	}
+	return resultsCount, nil
+}
+
+// All gets all the records of a bucket. If there are no records it returns no error and the 'to' parameter is set to an empty slice.
+func (s *MongoShim) All(to interface{}) error {
+	c, err := s.findWithConstraints(bson.M{}, to, &MongoQuery{})
+	if err != nil {
+		return err
+	}
+	// compatibility quirk
+	if c == 0 {
+		return mongo.ErrNoDocuments
+	}
+	return nil
+}
+
+func (s *MongoShim) Close() error {
+	return s.db.Client().Disconnect(s.ctx())
+}
+
+type MongoQuery struct {
+	orderBy []string
+	reverse bool
+
+	skip     *int64
+	limit    *int64
+	callback func(interface{}) error
+
+	matcher q.Matcher
+	s       *MongoShim
+}
+
+// Skip matching records by the given number
+func (q *MongoQuery) Skip(i int) Query {
+	v := int64(i)
+	q.skip = &v
+	return q
+}
+
+// Limit the results by the given number
+func (q *MongoQuery) Limit(i int) Query {
+	v := int64(i)
+	q.limit = &v
+	return q
+}
+
+// Order by the given fields, in descending precedence, left-to-right.
+func (q *MongoQuery) OrderBy(str ...string) Query {
+	q.orderBy = str
+	return q
+}
+
+// Reverse the order of the results
+func (q *MongoQuery) Reverse() Query {
+	q.reverse = true
+	return q
+}
+
+func (q *MongoQuery) opts() *options.FindOptions {
+	opts := options.Find()
+	// TODO: can be enabled when matchers are fully in bson otherwise results mismatch
+	//if q.limit != nil {
+	//	opts.SetLimit(*q.limit)
+	//}
+	//if q.skip != nil {
+	//	opts.SetSkip(*q.skip)
+	//}
+	if len(q.orderBy) > 0 {
+		sortOrder := 1 // ascending
+		if q.reverse {
+			sortOrder = -1
+		}
+		var sort bson.D
+		for _, field := range q.orderBy {
+			sort = append(sort, bson.E{
+				Key:   "V." + strings.ToLower(field),
+				Value: sortOrder,
+			})
+		}
+		opts.SetSort(sort)
+	}
+	return opts
+}
+
+// Find a list of matching records
+func (q *MongoQuery) Find(to interface{}) error {
+	c, err := q.s.findWithConstraints(bson.M{}, to, q)
+	if err != nil {
+		return err
+	}
+	// compatibility quirk
+	if c == 0 {
+		return mongo.ErrNoDocuments
+	}
+	return nil
+}
+
+// First gets the first matching record
+func (q *MongoQuery) First(to interface{}) error {
+	q.Limit(1)
+	c, err := q.s.findWithConstraints(bson.M{}, to, q)
+	if err != nil {
+		return err
+	}
+	// compatibility quirk
+	if c == 0 {
+		return mongo.ErrNoDocuments
+	}
+	return nil
+}
+
+// Execute the given function for each element
+func (q *MongoQuery) Each(kind interface{}, fn func(interface{}) error) error {
+	q.callback = fn
+	_, err := q.s.findWithConstraints(bson.M{}, kind, q)
+	return err
+}

--- a/storage/database/storm.go
+++ b/storage/database/storm.go
@@ -147,7 +147,3 @@ func (s StormQueryShim) First(to interface{}) error {
 func (s StormQueryShim) Each(kind interface{}, fn func(interface{}) error) error {
 	return s.q.Each(kind, fn)
 }
-
-func NotFound(err error) bool {
-	return err == storm.ErrNotFound
-}

--- a/storage/db/storm/dbset.go
+++ b/storage/db/storm/dbset.go
@@ -4,37 +4,52 @@ import "github.com/ProxeusApp/proxeus-core/storage"
 
 func NewDBSet(sDB storage.SettingsIF, folderPath string) (me *storage.DBSet, err error) {
 	me = &storage.DBSet{Settings: sDB}
-	me.I18n, err = NewI18nDB(folderPath)
+	settings, err := me.Settings.Get()
 	if err != nil {
 		return nil, err
 	}
-	me.Form, err = NewFormDB(folderPath)
+	conf := DBConfig{
+		Dir:    folderPath,
+		Engine: settings.DatabaseEngine,
+		URI:    settings.DatabaseURI,
+	}
+	me.I18n, err = NewI18nDB(conf)
 	if err != nil {
 		return nil, err
 	}
-	me.Template, err = NewDocTemplateDB(folderPath)
+	me.Form, err = NewFormDB(conf)
 	if err != nil {
 		return nil, err
 	}
-	me.Workflow, err = NewWorkflowDB(folderPath)
+	me.Template, err = NewDocTemplateDB(conf)
 	if err != nil {
 		return nil, err
 	}
-	me.User, err = NewUserDB(folderPath)
+	me.Workflow, err = NewWorkflowDB(conf)
 	if err != nil {
 		return nil, err
 	}
-	me.UserData, err = NewUserDataDB(folderPath)
+	me.User, err = NewUserDB(conf)
 	if err != nil {
 		return nil, err
 	}
-	me.SignatureRequests, err = NewSignatureDB(folderPath)
+	me.UserData, err = NewUserDataDB(conf)
 	if err != nil {
 		return nil, err
 	}
-	me.WorkflowPayments, err = NewWorkflowPaymentDB(folderPath)
+	me.SignatureRequests, err = NewSignatureDB(conf)
+	if err != nil {
+		return nil, err
+	}
+	me.WorkflowPayments, err = NewWorkflowPaymentDB(conf)
 	if err != nil {
 		return nil, err
 	}
 	return
+}
+
+type DBConfig struct {
+	Dir    string
+	Engine string
+	URI    string
 }

--- a/storage/db/storm/signature_requests.go
+++ b/storage/db/storm/signature_requests.go
@@ -18,15 +18,15 @@ const signatureVersion = "sig_vers"
 const signatureDBDir = "signaturerequests"
 const signatureDB = "signaturerequestsdb"
 
-func NewSignatureDB(dir string) (*SignatureRequestsDB, error) {
+func NewSignatureDB(c DBConfig) (*SignatureRequestsDB, error) {
 	var err error
 
-	baseDir := filepath.Join(dir, signatureDBDir)
+	baseDir := filepath.Join(c.Dir, signatureDBDir)
 	err = ensureDir(baseDir)
 	if err != nil {
 		return nil, err
 	}
-	db, err := database.OpenStorm(filepath.Join(baseDir, signatureDB))
+	db, err := database.OpenDatabase(c.Engine, c.URI, filepath.Join(baseDir, signatureDB))
 	if err != nil {
 		return nil, err
 	}

--- a/storage/db/storm/signature_requests_test.go
+++ b/storage/db/storm/signature_requests_test.go
@@ -2,20 +2,25 @@ package storm
 
 import (
 	"fmt"
+	"os"
 	"testing"
 	"time"
+
+	uuid "github.com/satori/go.uuid"
 
 	"github.com/ProxeusApp/proxeus-core/sys/model"
 )
 
 func TestSigning(t *testing.T) {
 	baseDir := "./testDir"
-	sigdb, err := NewSignatureDB(baseDir)
+	sigdb, err := NewSignatureDB(DBConfig{Dir: baseDir})
+	defer func() { os.RemoveAll(baseDir) }()
 	if err != nil {
 		t.Error(err)
 	}
 
 	sigreq := &model.SignatureRequestItem{}
+	sigreq.ID = uuid.NewV4().String()
 	sigreq.DocId = "abcd"
 	sigreq.DocPath = "1234"
 	sigreq.Signatory = "signatory_1"
@@ -23,6 +28,7 @@ func TestSigning(t *testing.T) {
 	sigreq.RequestedAt = time.Now()
 
 	sigreq2 := &model.SignatureRequestItem{}
+	sigreq2.ID = uuid.NewV4().String()
 	sigreq2.DocId = "abcd"
 	sigreq2.DocPath = "5678"
 	sigreq2.Signatory = "signatory_1"
@@ -31,6 +37,7 @@ func TestSigning(t *testing.T) {
 	sigreq2.RejectedAt = time.Now()
 
 	sigreq3 := &model.SignatureRequestItem{}
+	sigreq3.ID = uuid.NewV4().String()
 	sigreq3.DocId = "abcd"
 	sigreq3.DocPath = "1234"
 	sigreq3.Signatory = "signatory_2"

--- a/storage/db/storm/user_data_test.go
+++ b/storage/db/storm/user_data_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestPutGetData(t *testing.T) {
-	db, err := NewUserDataDB("./")
+	db, err := NewUserDataDB(DBConfig{Dir: "./"})
 	if err != nil {
 		t.Error(err)
 	}
@@ -110,7 +110,8 @@ func TestPutGetData(t *testing.T) {
 
 func TestPutGetDataFile(t *testing.T) {
 	dir := "./testDir"
-	db, err := NewUserDataDB(dir)
+	db, err := NewUserDataDB(DBConfig{Dir: dir})
+	defer func() { os.RemoveAll(dir) }()
 	if err != nil {
 		t.Error(err)
 	}
@@ -195,6 +196,4 @@ func TestPutGetDataFile(t *testing.T) {
 	log.Println("DATA", usrItem.Data)
 
 	db.Close()
-	//os.RemoveAll(dir)
-	//log.Println("err", usrData)
 }

--- a/storage/db/storm/user_test.go
+++ b/storage/db/storm/user_test.go
@@ -96,7 +96,7 @@ import (
 //}
 
 func TestUserDB_List(t *testing.T) {
-	udb, err := NewUserDB("")
+	udb, err := NewUserDB(DBConfig{Dir: ""})
 	if err != nil {
 		log.Println(err)
 	}
@@ -164,7 +164,7 @@ func insert(udb *UserDB, err error, orgID, orgEmail string, u model.User) {
 }
 
 func TestUserDB_List1(t *testing.T) {
-	udb, err := NewUserDB("")
+	udb, err := NewUserDB(DBConfig{Dir: ""})
 	if err != nil {
 		log.Println(err)
 	}
@@ -194,7 +194,7 @@ func TestNewUserDB(t *testing.T) {
 }
 
 func TestUserDB_List2(t *testing.T) {
-	udb, err := NewUserDB("")
+	udb, err := NewUserDB(DBConfig{Dir: ""})
 	if err != nil {
 		log.Println(err)
 	}

--- a/storage/db/storm/varHandler.go
+++ b/storage/db/storm/varHandler.go
@@ -2,7 +2,6 @@ package storm
 
 import (
 	"github.com/ProxeusApp/proxeus-core/storage/database"
-	"github.com/asdine/storm"
 	"github.com/asdine/storm/q"
 
 	"github.com/ProxeusApp/proxeus-core/sys/model"
@@ -26,7 +25,7 @@ func initVars(db database.DB) {
 func updateVarsOf(auth model.Auth, id string, allNewVars []string, tx database.DB) error {
 	var oldForm VarsMaintenance
 	err := tx.One("ID", id, &oldForm)
-	if err == storm.ErrNotFound {
+	if database.NotFound(err) {
 		//add vars
 		err = nil
 		oldForm = VarsMaintenance{}
@@ -75,7 +74,7 @@ func remVars(auth model.Auth, id string, tx database.DB) error {
 	var oldForm VarsMaintenance
 	err := tx.One("ID", id, &oldForm)
 	if err != nil {
-		if err == storm.ErrNotFound {
+		if database.NotFound(err) {
 			return nil
 		}
 		return err
@@ -91,7 +90,7 @@ func putVar(id, strVar string, tx database.DB) error {
 	var svar Var
 	err := tx.One("ID", strVar, &svar)
 	svarRef := &svar
-	if err == storm.ErrNotFound {
+	if database.NotFound(err) {
 		err = tx.Save(&Var{ID: strVar, VarRefs: map[string]bool{id: true}})
 		if err != nil {
 			return err
@@ -110,7 +109,7 @@ func remVar(id, strVar string, tx database.DB) error {
 	var svar Var
 	err := tx.One("ID", strVar, &svar)
 	svarRef := &svar
-	if err == storm.ErrNotFound {
+	if database.NotFound(err) {
 		return nil
 	} else {
 		delete(svarRef.VarRefs, id)

--- a/storage/db/storm/varHandler_test.go
+++ b/storage/db/storm/varHandler_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestVars(t *testing.T) {
-	db, err := NewUserDataDB("./")
+	db, err := NewUserDataDB(DBConfig{Dir: "./"})
 	if err != nil {
 		t.Error(err)
 		return

--- a/storage/portable/entities.go
+++ b/storage/portable/entities.go
@@ -93,7 +93,7 @@ func (ie *ImportExport) Import(t EntityType) error {
 func (ie *ImportExport) exportTemplate(id ...string) error {
 	if ie.db.Template == nil {
 		var err error
-		ie.db.Template, err = storm.NewDocTemplateDB(ie.dir)
+		ie.db.Template, err = storm.NewDocTemplateDB(ie.dbConfig)
 		if err != nil {
 			return err
 		}
@@ -162,7 +162,7 @@ func (ie *ImportExport) exportTemplate(id ...string) error {
 func (ie *ImportExport) importTemplate() error {
 	if ie.db.Template == nil {
 		var err error
-		ie.db.Template, err = storm.NewDocTemplateDB(ie.dir)
+		ie.db.Template, err = storm.NewDocTemplateDB(ie.dbConfig)
 		if err != nil {
 			return err
 		}
@@ -245,7 +245,7 @@ const allKeysMarker = "_all"
 func (ie *ImportExport) exportI18n(id ...string) error {
 	if ie.db.I18n == nil {
 		var err error
-		ie.db.I18n, err = storm.NewI18nDB(ie.dir)
+		ie.db.I18n, err = storm.NewI18nDB(ie.dbConfig)
 		if err != nil {
 			return err
 		}
@@ -299,7 +299,7 @@ func (ie *ImportExport) exportI18n(id ...string) error {
 func (ie *ImportExport) exportForm(id ...string) error {
 	if ie.db.Form == nil {
 		var err error
-		ie.db.Form, err = storm.NewFormDB(ie.dir)
+		ie.db.Form, err = storm.NewFormDB(ie.dbConfig)
 		if err != nil {
 			return err
 		}
@@ -361,7 +361,7 @@ func (ie *ImportExport) exportForm(id ...string) error {
 func (ie *ImportExport) exportWorkflow(id ...string) error {
 	if ie.db.Workflow == nil {
 		var err error
-		ie.db.Workflow, err = storm.NewWorkflowDB(ie.dir)
+		ie.db.Workflow, err = storm.NewWorkflowDB(ie.dbConfig)
 		if err != nil {
 			return err
 		}
@@ -462,7 +462,7 @@ func cpProfilePhoto(from storage.UserIF, to storage.UserIF, item *model.User) (e
 func (ie *ImportExport) exportUser(id ...string) error {
 	if ie.db.User == nil {
 		var err error
-		ie.db.User, err = storm.NewUserDB(ie.dir)
+		ie.db.User, err = storm.NewUserDB(ie.dbConfig)
 		if err != nil {
 			return err
 		}
@@ -502,7 +502,7 @@ func (ie *ImportExport) exportUser(id ...string) error {
 func (ie *ImportExport) exportUserData(id ...string) error {
 	if ie.db.UserData == nil {
 		var err error
-		ie.db.UserData, err = storm.NewUserDataDB(ie.dir)
+		ie.db.UserData, err = storm.NewUserDataDB(ie.dbConfig)
 		if err != nil {
 			return err
 		}
@@ -611,7 +611,7 @@ func (ie *ImportExport) importSettings() error {
 func (ie *ImportExport) importI18n() error {
 	if ie.db.I18n == nil {
 		var err error
-		ie.db.I18n, err = storm.NewI18nDB(ie.dir)
+		ie.db.I18n, err = storm.NewI18nDB(ie.dbConfig)
 		if err != nil {
 			return err
 		}
@@ -669,7 +669,7 @@ func (ie *ImportExport) importI18n() error {
 func (ie *ImportExport) importForm() error {
 	if ie.db.Form == nil {
 		var err error
-		ie.db.Form, err = storm.NewFormDB(ie.dir)
+		ie.db.Form, err = storm.NewFormDB(ie.dbConfig)
 		if err != nil {
 			return err
 		}
@@ -726,7 +726,7 @@ func (ie *ImportExport) importForm() error {
 func (ie *ImportExport) importWorkflow() error {
 	if ie.db.Workflow == nil {
 		var err error
-		ie.db.Workflow, err = storm.NewWorkflowDB(ie.dir)
+		ie.db.Workflow, err = storm.NewWorkflowDB(ie.dbConfig)
 		if err != nil {
 			return err
 		}
@@ -760,7 +760,7 @@ func (ie *ImportExport) importWorkflow() error {
 func (ie *ImportExport) importUser() error {
 	if ie.db.User == nil {
 		var err error
-		ie.db.User, err = storm.NewUserDB(ie.dir)
+		ie.db.User, err = storm.NewUserDB(ie.dbConfig)
 		if err != nil {
 			return err
 		}
@@ -860,7 +860,7 @@ func updateEmptyFields(of, by *model.User) {
 func (ie *ImportExport) importUserData() error {
 	if ie.db.UserData == nil {
 		var err error
-		ie.db.UserData, err = storm.NewUserDataDB(ie.dir)
+		ie.db.UserData, err = storm.NewUserDataDB(ie.dbConfig)
 		if err != nil {
 			return err
 		}

--- a/storage/portable/import-export.go
+++ b/storage/portable/import-export.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/ProxeusApp/proxeus-core/storage"
+	"github.com/ProxeusApp/proxeus-core/storage/db/storm"
 	"github.com/ProxeusApp/proxeus-core/sys/model"
 	"github.com/ProxeusApp/proxeus-core/sys/tar"
 
@@ -26,6 +27,7 @@ type ImportExport struct {
 	auth                    model.Auth
 	sysDB                   *storage.DBSet
 	db                      *storage.DBSet
+	dbConfig                storm.DBConfig
 	skipExistingOnImport    bool
 	processed               ProcessedResults
 	neededUsers             map[string]bool
@@ -58,6 +60,7 @@ func NewImportExport(auth model.Auth, dbSet *storage.DBSet, dir string) (*Import
 	if err != nil {
 		return nil, err
 	}
+	ie.dbConfig = storm.DBConfig{Engine: "storm", Dir: ie.dir}
 	ie.auth = auth
 	return ie, nil
 }

--- a/sys/form/form.go
+++ b/sys/form/form.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	r "reflect"
 
+	"github.com/ProxeusApp/proxeus-core/sys/model/compatability"
+
 	"github.com/ProxeusApp/proxeus-core/sys/validate"
 )
 
@@ -115,7 +117,7 @@ func RulesOf(formSrc interface{}, fieldName string) (vRules validate.Rules) {
 }
 
 func toMapStringInterface(d interface{}) (map[string]interface{}, error) {
-	m, ok := d.(map[string]interface{})
+	m, ok := compatability.ToMapStringIF(d)
 	if !ok {
 		sSpec, ok := d.(string)
 		if ok {
@@ -132,7 +134,7 @@ func toMapStringInterface(d interface{}) (map[string]interface{}, error) {
 
 func GetFormSrc(formSrc interface{}) map[string]interface{} {
 	if formSrc != nil {
-		formSrcMap, ok := formSrc.(map[string]interface{})
+		formSrcMap, ok := compatability.ToMapStringIF(formSrc)
 		if ok {
 			if formSrcInner, ok := formSrcMap["formSrc"]; ok {
 				formSrcInnerMap, ok := formSrcInner.(map[string]interface{})
@@ -148,7 +150,7 @@ func GetFormSrc(formSrc interface{}) map[string]interface{} {
 
 func LoopComponents(formSrc interface{}, looper func(compId, compInstId string, compMain interface{}, comp map[string]interface{}) bool) {
 	if formSrc != nil {
-		formSrcMap, ok := formSrc.(map[string]interface{})
+		formSrcMap, ok := compatability.ToMapStringIF(formSrc)
 		if !ok {
 			return
 		}

--- a/sys/model/all.go
+++ b/sys/model/all.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/ProxeusApp/proxeus-core/sys/model/compatability"
+
 	"github.com/ProxeusApp/proxeus-core/sys/file"
 	"github.com/ProxeusApp/proxeus-core/sys/workflow"
 )
@@ -29,7 +31,7 @@ type (
 		Created time.Time `json:"created" storm:"index"`
 
 		//Data contains the form source
-		Data map[string]interface{} `json:"data"`
+		Data compatability.CarriedStringMap `json:"data"`
 	}
 
 	UserDataItem struct {
@@ -43,7 +45,7 @@ type (
 		Updated    time.Time `json:"updated" storm:"index"`
 		Created    time.Time `json:"created" storm:"index"`
 
-		Data map[string]interface{} `json:"data"`
+		Data compatability.CarriedStringMap `json:"data"`
 	}
 
 	FormComponentItem struct {
@@ -56,8 +58,8 @@ type (
 		Created time.Time `json:"created" storm:"index"`
 
 		//Settings and Template are just passing through
-		Settings interface{} `json:"settings"`
-		Template interface{} `json:"template"`
+		Settings compatability.CarriedJsonRaw `json:"settings"`
+		Template string                       `json:"template"`
 	}
 
 	WorkflowItem struct {
@@ -88,7 +90,7 @@ type (
 	}
 
 	SignatureRequestItem struct {
-		ID int `storm:"id,increment"`
+		ID string `storm:"id"`
 		// DocumentID, ie. 8b5e1460-e456-4aea-91dd-efd7f6ff9b40
 		DocId string `json:"docid" storm:"index"`
 		// DataPath, ie. docs[0]

--- a/sys/model/compatability/helpers.go
+++ b/sys/model/compatability/helpers.go
@@ -1,0 +1,44 @@
+package compatability
+
+import (
+	"encoding/json"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type CarriedJsonRaw struct {
+	json.RawMessage
+}
+
+type CarriedStringMap map[string]interface{}
+
+func (c CarriedStringMap) MarshalBSON() ([]byte, error) {
+	raw, err := json.Marshal(&c)
+	if err != nil {
+		return nil, err
+	}
+	v := bson.M{"d": raw}
+	return bson.Marshal(v)
+}
+
+func (c *CarriedStringMap) UnmarshalBSON(raw []byte) error {
+	v := bson.M{"d": primitive.Binary{}}
+	err := bson.Unmarshal(raw, &v)
+	if err != nil {
+		return err
+	}
+	b := v["d"].(primitive.Binary).Data
+	if len(b) == 0 || string(b) == "null" {
+		b = []byte{'{', '}'}
+	}
+	return json.Unmarshal(b, c)
+}
+
+func ToMapStringIF(d interface{}) (map[string]interface{}, bool) {
+	if dd, ok := d.(CarriedStringMap); ok {
+		return dd, true
+	}
+	dd, ok := d.(map[string]interface{})
+	return dd, ok
+}

--- a/sys/model/lang.go
+++ b/sys/model/lang.go
@@ -5,7 +5,8 @@ import (
 )
 
 type Lang struct {
-	Code    string `storm:"id"`
+	ID      string
+	Code    string
 	Enabled bool
 }
 

--- a/sys/model/settings.go
+++ b/sys/model/settings.go
@@ -19,6 +19,8 @@ type Settings struct {
 	AirdropEnabled            string `json:"airdropEnabled" validate:"required=true" default:"false" usage:"Enables/Disables the XES & Ether airdrop feature on ropsten."`
 	AirdropAmountXES          string `json:"airdropAmountXES" default:"0" usage:"Amount of XES to airdrop to newly registered users."`
 	AirdropAmountEther        string `json:"airdropAmountEther" default:"0" usage:"Amount of Ether to airdrop to newly registered users."`
+	DatabaseEngine            string `json:"databaseEngine" default:"storm" usage:"Selects database engine, supported values: storm, mongo."`
+	DatabaseURI               string `json:"DatabaseURI" default:"" usage:"Sets database connection string, not required for embedded databases."`
 	TestMode                  string `json:"testMode" default:"false" usage:"Run the server in test mode (NOT FOR PRODUCTION)."`
 }
 

--- a/sys/workflow/js.go
+++ b/sys/workflow/js.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/ProxeusApp/proxeus-core/sys/model/compatability"
+
 	"github.com/robertkrimen/otto"
 )
 
@@ -19,7 +21,7 @@ func NewJSParser() *JS {
 
 func (js *JS) SetGlobal(data interface{}) error {
 	if data != nil {
-		if dataMap, ok := data.(map[string]interface{}); ok {
+		if dataMap, ok := compatability.ToMapStringIF(data); ok {
 			for name, v := range dataMap {
 				if v != nil {
 					b, err := json.Marshal(v)

--- a/sys/workflow/node.go
+++ b/sys/workflow/node.go
@@ -2,6 +2,8 @@ package workflow
 
 import (
 	"fmt"
+
+	"github.com/ProxeusApp/proxeus-core/sys/model/compatability"
 )
 
 type (
@@ -21,19 +23,19 @@ type (
 	InitImplFunc func(n *Node) (NodeIF, error)
 
 	Node struct {
-		ID           string                 `json:"id"`
-		Name         string                 `json:"name"`
-		Type         string                 `json:"type"`
-		Detail       string                 `json:"detail,omitempty"`
-		Data         map[string]interface{} `json:"data,omitempty"`
-		Cases        []*Case                `json:"cases,omitempty"`
-		Connections  []*Connection          `json:"conns,omitempty"`
-		Position     Position               `json:"p"`
-		context      *context               `json:"-"`
-		internalNode bool                   `json:"-"`
-		err          error                  `json:"-"`
-		impl         NodeIF                 `json:"-"`
-		background   bool                   `json:"-"`
+		ID           string                         `json:"id"`
+		Name         string                         `json:"name"`
+		Type         string                         `json:"type"`
+		Detail       string                         `json:"detail,omitempty"`
+		Data         compatability.CarriedStringMap `json:"data,omitempty"`
+		Cases        []*Case                        `json:"cases,omitempty"`
+		Connections  []*Connection                  `json:"conns,omitempty"`
+		Position     Position                       `json:"p"`
+		context      *context                       `json:"-"`
+		internalNode bool                           `json:"-"`
+		err          error                          `json:"-"`
+		impl         NodeIF                         `json:"-"`
+		background   bool                           `json:"-"`
 		new          InitImplFunc
 	}
 )

--- a/test/database/mongo_test.go
+++ b/test/database/mongo_test.go
@@ -1,0 +1,31 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/ProxeusApp/proxeus-core/storage/database"
+)
+
+func openMongoDB(t *testing.T) *database.MongoShim {
+	db, err := database.OpenMongo("mongodb://localhost:27017", "db00")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func TestCRUDMongo(t *testing.T) {
+	testCRUD(t, openMongoDB(t))
+}
+
+func TestGetQuirksMongo(t *testing.T) {
+	testGetQuirks(t, openMongoDB(t))
+}
+
+func TestAdvancedFetchingMongo(t *testing.T) {
+	testAdvancedFetching(t, openMongoDB(t))
+}
+
+func TestTransactionsMongo(t *testing.T) {
+	testTransactions(t, openMongoDB(t))
+}


### PR DESCRIPTION
    * Added example config for setting up mongo locally, under demo/mongodb.
    Mongo needs to run in replica set to support transactions!

    * Database format is not compatible with previous one (i.e. database
    wipe needed before the upgrade). This is due to small but important changes
    mostly around storing of interface{} types (see compatibility/helpers.go).

