### PR TITLE
Remove hashicorp lib from approved license

### DIFF
--- a/doc/dependency_decisions.yml
+++ b/doc/dependency_decisions.yml
@@ -372,12 +372,6 @@
     :versions: []
     :when: 2019-12-19 16:10:34.591361000 Z
 - - :approve
-  - github.com/hashicorp/golang-lru
-  - :who: emeka.mosanya@blockfactory.com
-    :why: MPL-2.0
-    :versions: []
-    :when: 2019-12-20 14:36:29.990129000 Z
-- - :approve
   - github.com/allegro/bigcache
   - :who: emeka.mosanya@blockfactory.com
     :why: Apache-2.0


### PR DESCRIPTION
Hashicorp github.com/hashicorp/golang-lru lib is MPL-2.0 with Exhibit B which makes is GPL incompatible.  Removing from the approved list for now.