### PR TITLE
Go documentation generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,20 @@ jobs:
           name: Validate
           command: make init validate
 
+  doc-go:
+    executor: docker-image-golang
+    resource_class: large
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - go-mod-v2-{{ checksum "go.sum" }}
+      - run:
+          name: Generate doc
+          command: make doc
+      - store_artifacts:
+          path: artifacts/godoc.tar.gz
+
   test-go:
     executor: docker-image-golang
     steps:
@@ -265,6 +279,9 @@ workflows:
           requires:
             - test-integration-go
       - coverage-go:
+          requires:
+            - build-go
+      - doc-go:
           requires:
             - build-go
       - build-server-docker:


### PR DESCRIPTION
A Go doc can now be generated through `make doc`

Documentation's HTML is stored into a .tar.gz as artifact in CircleCI. 

Preview:
![image](https://user-images.githubusercontent.com/1556466/75036688-c1c44a00-54b2-11ea-8fa4-94b62fe51995.png)



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[coding style](coding_style.md)** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.