### PR TITLE
Enable delete Workflow by removing return statement

### DIFF
--- a/test/workflow_test.go
+++ b/test/workflow_test.go
@@ -154,7 +154,6 @@ func hasUserWorkflow(s *session, containsW *workflow) {
 }
 
 func deleteWorkflow(s *session, id string, expectEmptyList bool) {
-	return
 	s.e.GET(fmt.Sprintf("/api/admin/workflow/%s/delete", id)).Expect().Status(http.StatusOK)
 	l := s.e.GET("/api/admin/workflow/list").Expect()
 


### PR DESCRIPTION
# Pull Request Details

Delete workflow did not run due to a return statement that has been removed

## How Has This Been Tested

API tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[coding style](coding_style.md)** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.