### PR TITLE
Ensures external node test wait for node ready

### DIFF
--- a/main/handlers/api/handlers.go
+++ b/main/handlers/api/handlers.go
@@ -1981,6 +1981,13 @@ func ExternalRegister(e echo.Context) error {
 	return c.System().DB.Workflow.RegisterExternalNode(new(model.User), &node)
 }
 
+func ExternalList(e echo.Context) error {
+	c := e.(*www.Context)
+	nodes := c.System().DB.Workflow.ListExternalNodes()
+
+	return c.JSON(http.StatusOK, nodes)
+}
+
 func ExternalConfigStore(e echo.Context) error {
 	c := e.(*www.Context)
 

--- a/main/handlers/routes.go
+++ b/main/handlers/routes.go
@@ -202,6 +202,7 @@ func MainHostedAPI(e *echo.Echo, s *www.Security, version string) {
 
 		//external node
 		{POST, PUBLIC, "/api/admin/external/register", api.ExternalRegister},
+		{GET, PUBLIC, "/api/admin/external/list", api.ExternalList},
 		{POST, PUBLIC, "/api/admin/external/config/:id", api.ExternalConfigStore},
 		{GET, PUBLIC, "/api/admin/external/config/:id", api.ExternalConfigRetrieve},
 		{GET, CREATOR, "/api/admin/external/:name/:id", api.ExternalConfigurationPage}, // Need session

--- a/test/workflow_external_node_test.go
+++ b/test/workflow_external_node_test.go
@@ -1,6 +1,9 @@
 package test
 
 import (
+	"strings"
+	"time"
+
 	"github.com/ProxeusApp/proxeus-core/externalnode"
 
 	"net/http"
@@ -14,6 +17,11 @@ const (
 )
 
 func testWorkflowExternalNode(s *session) {
+
+	if !externalNodeAvailable(s, "Crypto to Fiat Forex Rates") {
+		s.t.Fatal("external node not available")
+	}
+
 	u := registerTestUser(s)
 	login(s, u)
 
@@ -88,6 +96,17 @@ func setExternalNodeConfig(s *session, id string, config interface{}) {
 
 func getExternalNodeConfig(s *session, id string, config interface{}) {
 	s.e.GET("/api/admin/external/config/" + id).Expect().Status(http.StatusOK)
+}
+
+func externalNodeAvailable(s *session, name string) bool {
+	for i := 0; i < 10; i++ {
+		list := s.e.GET("/api/admin/external/list").Expect().Status(http.StatusOK).Body().Raw()
+		if strings.Contains(list, name) {
+			return true
+		}
+		time.Sleep(time.Second)
+	}
+	return false
 }
 
 const workflowXData = `{


### PR DESCRIPTION
# Pull Request Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

Before the external node tests started even if the external node was not registered.
Now the test will check if it is registered.  If it is not registered after 10s then the test fails.

## Motivation and Context

Test flakiness.

## How Has This Been Tested

Run `make test-api`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **[coding style](coding_style.md)** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.