### PR TITLE
Fix default user roles conversion

### DIFF
--- a/ui/core/src/views/appDependentComponents/SettingsInner.vue
+++ b/ui/core/src/views/appDependentComponents/SettingsInner.vue
@@ -44,7 +44,7 @@
                             v-model="settings.cacheExpiry">
               <span class="text-muted">{{$t('Cache expiry explanation','Set the common cache expiry which will be used for email tokens or similar like 1h as one hour, 1m as one minute or 1s as one second.')}}</span>
               <simple-select :unselect="false" style="margin-top: 15px;" name="settings.defaultRole"
-                             v-model="settings.defaultRole" :idProp="'role'" :labelProp="'name'" :options="app.roles"/>
+                             v-model="settings.defaultRole" :idProp="'role'" :labelProp="'name'" :options="defaultUserRoles"/>
               <span class="text-muted">{{$t('Default role explanation','Select the default role that is going to be used for new registrations.')}}</span>
             </animated-input>
             <animated-input name="settings.documentServiceUrl" :max="100" :label="$t('Document Service URL')"
@@ -167,6 +167,11 @@ export default {
     }
   },
   updated () {
+  },
+  computed: {
+    defaultUserRoles () {
+      return this.app.roles.map(roleObj => { return { 'name': roleObj.name, 'role': roleObj.name.toLowerCase() } })
+    }
   },
   methods: {
     getInit (cb) {


### PR DESCRIPTION
Fix user roles int to string conversion

## Description

Instead of posting an int to the api, now a string is posted

## Motivation and Context

Fixes issue that defaultUserRole could not be saved

## How Has This Been Tested

Manual tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[coding style](coding_style.md)** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.