### PR TITLE
Reinstantiate emailSender on postInit

### DIFF
--- a/main/main.go
+++ b/main/main.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/ProxeusApp/proxeus-core/main/handlers/template_ide"
 
-	"github.com/ProxeusApp/proxeus-core/sys/email"
-
 	"github.com/ProxeusApp/proxeus-core/main/handlers/formbuilder"
 
 	"github.com/ProxeusApp/proxeus-core/main/handlers/workflow"
@@ -85,8 +83,7 @@ func main() {
 	templateDocumentService := service.NewTemplateDocumentService()
 	userDocumentService := service.NewUserDocumentService(userService, fileService, templateDocumentService)
 
-	emailSender, err := email.NewSparkPostEmailSender(system.GetSettings().SparkpostApiKey, system.GetSettings().EmailFrom)
-	emailService := service.NewEmailService(emailSender)
+	emailService := service.NewEmailService()
 	signatureService := service.NewSignatureService(fileService, userService, emailService)
 	formService := service.NewFormService()
 	formComponentService := service.NewFormComponentService()

--- a/service/base.go
+++ b/service/base.go
@@ -3,6 +3,7 @@ package service
 import (
 	"github.com/ProxeusApp/proxeus-core/storage"
 	"github.com/ProxeusApp/proxeus-core/sys"
+	"github.com/ProxeusApp/proxeus-core/sys/email"
 )
 
 var system *sys.System
@@ -49,4 +50,8 @@ func signatureRequestDB() storage.SignatureRequestsIF {
 
 func sessionDB() storage.SessionIF {
 	return system.DB.Session
+}
+
+func emailSender() email.EmailSender {
+	return system.EmailSender
 }

--- a/service/email.go
+++ b/service/email.go
@@ -10,12 +10,11 @@ type (
 		SendFrom(emailFrom, emailTo, subject, body string) error
 	}
 	DefaultEmailService struct {
-		emailSender email.EmailSender
 	}
 )
 
-func NewEmailService(emailS email.EmailSender) EmailService {
-	return &DefaultEmailService{emailSender: emailS}
+func NewEmailService() EmailService {
+	return &DefaultEmailService{}
 }
 
 // Send dispatches an email. The body can contain html tags.
@@ -34,5 +33,5 @@ func (me *DefaultEmailService) Send(emailTo, subject, body string) error {
 func (me *DefaultEmailService) SendFrom(emailFrom, emailTo, subject, body string) error {
 	mail := &email.Email{From: emailFrom, To: []string{emailTo}, Subject: subject, Body: body}
 
-	return me.emailSender.Send(mail)
+	return emailSender().Send(mail)
 }

--- a/sys/system.go
+++ b/sys/system.go
@@ -40,10 +40,11 @@ var (
 
 type (
 	System struct {
-		TestMode  bool
-		AllowHttp bool
-		DB        *storage.DBSet
-		DS        *eio.DocumentServiceClient
+		TestMode    bool
+		AllowHttp   bool
+		DB          *storage.DBSet
+		DS          *eio.DocumentServiceClient
+		EmailSender email.EmailSender
 
 		settingsDB                  storage.SettingsIF
 		settingsInUse               model.Settings
@@ -84,7 +85,7 @@ func (me *System) init(stngs *model.Settings) error {
 	me.settingsInUse.DocumentServiceUrl = stngs.DocumentServiceUrl
 
 	var err error
-	emailSender, err := email.NewSparkPostEmailSender(stngs.SparkpostApiKey, stngs.EmailFrom)
+	me.EmailSender, err = email.NewSparkPostEmailSender(stngs.SparkpostApiKey, stngs.EmailFrom)
 	if err != nil {
 		return err
 	}
@@ -161,7 +162,7 @@ func (me *System) init(stngs *model.Settings) error {
 	} else {
 		logSubscriber = blockchain.NewWebSocketLogSubscriber(dialler, cfg.Config.EthWebSocketURL, stngs.BlockchainContractAddress)
 	}
-	bcListenerSignature := blockchain.NewSignatureListener(me.DB.SignatureRequests, me.DB.User, emailSender, ProxeusFSABI, cfg.Config.PlatformDomain, logSubscriber)
+	bcListenerSignature := blockchain.NewSignatureListener(me.DB.SignatureRequests, me.DB.User, me.EmailSender, ProxeusFSABI, cfg.Config.PlatformDomain, logSubscriber)
 	ctxSig := context.Background()
 	ctxSig, cancelSig := context.WithCancel(ctxPay)
 	if me.signatureListenerCancelFunc != nil {


### PR DESCRIPTION
# Pull Request Details

Reinstanciate emailSend on PostInit.
Before that change the api key would not change when sending an email after changing the api key in the settings


## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[coding style](coding_style.md)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.