### PR TITLE
Fix incomplete user listing

### DIFF
--- a/storage/database/user.go
+++ b/storage/database/user.go
@@ -235,7 +235,10 @@ func (me *UserDB) List(auth model.Auth, contains string, options storage.Options
 		} else {
 			matchers = append(matchers,
 				q.And(
-					q.Eq("WantToBeFound", true),
+					q.Or(
+						q.Eq("WantToBeFound", true),
+						q.Eq("ID", auth.UserID()),
+					),
 					q.Or(
 						q.Re("Email", contains),
 						q.Re("Name", contains),
@@ -248,7 +251,11 @@ func (me *UserDB) List(auth model.Auth, contains string, options storage.Options
 	} else {
 		if !auth.AccessRights().IsGrantedForUserModifications() {
 			matchers = append(matchers,
-				q.Eq("WantToBeFound", true))
+				q.Or(
+					q.Eq("WantToBeFound", true),
+					q.Eq("ID", auth.UserID()),
+				),
+			)
 		}
 	}
 	if len(params.exclude) > 0 {

--- a/storage/database/user_test.go
+++ b/storage/database/user_test.go
@@ -43,8 +43,7 @@ func TestUser(t *testing.T) {
 	Expect(us.GetByEmail(email)).To(equalJSON(item))
 	Expect(us.Count()).To(Equal(2))
 	Expect(us.List(dummySuperAdmin, email, options)).To(equalJSON([]*model.User{item}))
-	_, err := us.List(dummy, email, options)
-	Expect(err).To(HaveOccurred())
+	Expect(us.List(dummy, email, options)).To(equalJSON([]*model.User{item}))
 
 	// profile photo
 	phData := []byte("img_data")
@@ -53,7 +52,7 @@ func TestUser(t *testing.T) {
 	buf.Reset()
 	Expect(us.GetProfilePhoto(dummySuperAdmin, item.ID, buf)).To(Succeed())
 	Expect(buf.Bytes()).To(Equal(phData))
-	_, err = us.List(dummySuperAdmin, "", options)
+	_, err := us.List(dummySuperAdmin, "", options)
 	Expect(err).To(Succeed())
 
 	// api keys


### PR DESCRIPTION
# Pull Request Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fix incomplete user listing by disregarding the wanttobefound setting in case of listing the users own user object.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
User's own user should be listed to them regardless of privacy settings meant for other users.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual & Automated Tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[coding style](coding_style.md)** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.