### PR TITLE
Remove cookie on browser close instead of after 30 min

### DIFF
--- a/main/www/session.go
+++ b/main/www/session.go
@@ -63,7 +63,6 @@ func getSessionWithUser(c *Context, create bool, usr *model.User) (currentSessio
 			sess.Values["id"] = currentSession.S.ID
 			options := sessions.Options{
 				Path:     "/",
-				MaxAge:   60 * 30, // 30 minutes,
 				HttpOnly: true,
 				SameSite: http.SameSiteStrictMode,
 				Secure:   true,


### PR DESCRIPTION
Currently the session cookie max age is set to 30min. A user would always get logged out after 30min. Remove the max age setting so the cookie is removed only on browser close.

In the backend the session is still removed according to the settings in "Session Expiry" and is renewed on every request.


## How Has This Been Tested

Manual test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[coding style](coding_style.md)** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.