### PR TITLE
Fix Import and Export of Documents and Templates

### DIFF
--- a/main/handlers/api/handlers.go
+++ b/main/handlers/api/handlers.go
@@ -132,6 +132,7 @@ func GetExport(e echo.Context) error {
 	var exportEntities []portable.EntityType
 	if strings.ToLower(c.Request().Method) == "get" {
 		spl := strings.Split(c.QueryParam("include"), ",")
+		log.Println("[Export][GET] About to export: ", c.QueryParam("include"))
 		for _, s := range spl {
 			s = strings.TrimSpace(s)
 			entity := portable.StringToEntityType(s)
@@ -140,6 +141,7 @@ func GetExport(e echo.Context) error {
 			}
 		}
 	} else {
+		log.Printf("[Export][POST] exportEntities: %+v", exportEntities)
 		_ = c.Bind(&exportEntities)
 	}
 	if len(exportEntities) == 0 {


### PR DESCRIPTION
Fixes importing and exporting of documents and templates. The import and export omits importing and exporting linked files of Documents and Templates. Due to a panic in boltdb "invalid page type:...."while copying the filesdb copying of files was removed. The consequence is that users have to manually add template and document files.

## How Has This Been Tested

Manual tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[coding style](coding_style.md)** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
