### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,16 @@
 version: 2
 updates:
-  target-branch: "preprod"
   
   # Maintain dependencies for Go
   - package-ecosystem: "gomod"
     directory: "/"
+    target-branch: "preprod"
     schedule:
       interval: "weekly"
 
   # Maintain dependencies for JS
   - package-ecosystem: "npm"
     directory: "/ui/"
+    target-branch: "preprod"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,7 @@
 version: 2
 updates:
+  target-branch: "preprod"
+  
   # Maintain dependencies for Go
   - package-ecosystem: "gomod"
     directory: "/"


### PR DESCRIPTION
We use Dependabot for automated assistance in keeping this project up to date.

However, the auto-PRs should target the "preprod" branch instead of main.

Related to #324