### PR TITLE
Disable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 version: 2
-updates:
+disabled:
   
   # Maintain dependencies for Go
   - package-ecosystem: "gomod"


### PR DESCRIPTION
As this project is being archived, I am disabling the Dependabot configuration. It can be quickly re-activated.